### PR TITLE
Fix confusing/wrong section header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ FAQ
 1. This runs on any platform that supports Java and is non [headless](https://en.wikipedia.org/wiki/Headless_software). AutoHotkey is written for Windows. Repeat works fine on your Linux machine at work as well as your Window gaming setup at home.
 2. The only limit to your hotkey power is your knowledge of the language you write your tasks in (e.g. Java, Python or C#). You don't have to learn a new meta language provided by AutoHotkey. This allows you to leverage your expertise in the language chosen and/or the immense support from the internet.
 
-## Why is this only available in headless system?
+## Why is this not available on headless systems?
 It does not make sense to listen to keyboard and mouse events in a headless system. How can you move your mouse if you have no screen? What would typing a key mean in such system?
 
 ## How do I change the global hotkeys (e.g. run task, start recording, stop recording)?


### PR DESCRIPTION
To be clear, a [headless system](https://en.wikipedia.org/wiki/Headless_computer) is a computer that has no screen.

So unless you really do mean that this software *doesn't* work on computers that *do* have a screen (e.g. it *won't* work on my Windows laptop, but *will* work on my Linux server that's only accessible via SSH) what you really meant to say here is that it is *not* available on head*less* systems. (I.E. It *won't* work on systems that *don't* have a screen. It *will* work on systems that *do* have a screen.)